### PR TITLE
Run os tests in matrix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,35 +1,31 @@
 version: 2.1
 
-jobs:
-  test-linux:
+executors:
+  docker: # Docker using the Base Convenience Image
     docker:
-      - image: cimg/base:current
-    working_directory: ~/asdf-lein
-    steps:
-      - checkout
-      - run:
-          command: |
-            cd ~/
-            git clone https://github.com/asdf-vm/asdf.git asdf
-            ls
-            . asdf/asdf.sh
-            asdf plugin test lein $CIRCLE_WORKING_DIRECTORY 'lein --version'
-            # asdf plugin test <plugin-name> <plugin-url> [--asdf-tool-version <version>] [--asdf-plugin-gitref <git-ref>] [test-command*]
-            # asdf plugin test nodejs https://github.com/asdf-vm/asdf-nodejs.git node --version
-
-  test-macos:
+      - image: cimg/base:stable
+  macos: # macOS executor running Xcode
     macos:
       xcode: 14.2.0
-    working_directory: ~/asdf-lein
+
+jobs:
+  test:
+    parameters:
+      os:
+        type: executor
+    executor: << parameters.os >>
     steps:
       - checkout
       - run:
           command: |
             git clone https://github.com/asdf-vm/asdf.git asdf
             . asdf/asdf.sh
-            asdf plugin test lein $CIRCLE_WORKING_DIRECTORY  'lein --version'
+            asdf plugin test lein $CIRCLE_WORKING_DIRECTORY 'lein --version'
+
 workflows:
-  test:
+  test-plugin:
     jobs:
-      - test-linux
-      - test-macos
+      - test:
+          matrix:
+            parameters:
+              os: [docker, macos]


### PR DESCRIPTION
... as shown in https://circleci.com/docs/using-matrix-jobs/\#use-matrix-jobs-to-run-multiple-os-tests

Also removed the working dir stuff. 

I think there is no need to define it, as the `git clone` will place asdf to subdir anyways, so working_dir name shouldn't matter.

And thx for the fork, will take it into use when you get the CI running and changes merged to main branch 👍 